### PR TITLE
Proof-of-concept federation over fedora 3 content.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+target/
+.classpath
+.settings/
+.project
+.metadata
+ActiveMQ/
+FedoraRepository/
+indexes/
+ObjectStore/
+*/.cache
+.cache
+.DS_Store
+*~

--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# Fedora 3 Federation Connector
+
+This fedoration connector allows exposure of fedora 3 content in a running fedora 3 repository
+to appear within a fedora 4 repository.  To use this code, you'd need to have access to a fedora 3 repository.
+
+[Design Documentation](https://wiki.duraspace.org/display/FF/Design+-+Fedora+3+to+4+Upgrade)
+
+## Fetching the source code
+
+```bash
+$ git clone https://github.com/futures/fcrepo4.git
+$ cd fcrepo4
+$ git clone https://github.com/mikedurbin/fcrepo-fedora3-federation-connector
+```
+### Update build configuration to include new module
+In fcrepo4/pom.xml add
+
+	<module>fcrepo-fedora3-federation-connector</module>
+
+In fcrepo4/fcrepo4-webapp/pom.xml add
+
+	<dependency>
+	  <groupId>org.fcrepo</groupId>
+	  <artifactId>fcrepo-fedora3-federation-connector</artifactId>
+	  <version>${project.version}</version>
+	</dependency>
+
+In fcrepo4/fcrepo-kernel/src/main/resources/fedora-node-types.cnd add
+
+	/*
+	 * A federated fedora 3 repository
+	 */
+	[fedora:repository]
+
+In fcrepo4/fcrepo-jcr/src/main/resources/config/single/repository.json (or whichever you're using) add
+
+	"externalSources" : {
+	  "fedora3" : {
+	     "classname" : "org.fcrepo.connector.fedora3.Fedora3FederationConnector",
+	     "projections" : [ "default:/f3 => /" ],
+	     "fedoraUrl" : "http://localhost-or-wherever-your-fedora3-is/fedora",
+	     "username" : "your-fedora-username",
+	     "password" : "your-fedora-password",
+             "pageSize" : 10
+	  }
+	}
+
+Note: pageSize is optional and represents the size of pages of objects that are the child nodes of the
+repository node.
+
+### Compile and install the code
+```bash
+$ mvn clean install
+$ cd fcrepo-webapp
+$ mvn jetty:run
+```
+
+You can see the federation over your fedora 3 content at [http://localhost:8080/rest/f3](http://localhost:8080/rest/f3)
+
+## Caveats
+
+* right now, the number of objects in the repository that are exposed is reduced to 21 to simplify testing
+* datastream content doesn't yet behave properly
+* versions are not presented
+* a great deal of fedora 3 attributes and metadata aren't yet made available
+* no integration tests
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.fcrepo</groupId>
+    <artifactId>fcrepo</artifactId>
+    <version>4.0.0-alpha-2-SNAPSHOT</version>
+  </parent>
+  <artifactId>fcrepo-fedora3-federation-connector</artifactId>
+  <name>${project.artifactId}</name>
+  <description>
+      A package of federation connectors that can be used to project
+      over fedora 3 content.
+  </description>
+  <properties>
+      <modeshape.version>3.4.0.Final</modeshape.version>
+  </properties>
+  <packaging>bundle</packaging>
+    <dependencies>
+    <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-kernel</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yourmediashelf.fedora.client</groupId>
+      <artifactId>fedora-client-core</artifactId>
+      <version>0.7</version>
+      <exclusions>
+        <exclusion>
+          <groupId>xerces</groupId>
+          <artifactId>xercesImpl</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+ </dependencies>
+</project>

--- a/src/main/java/org/fcrepo/connector/fedora3/Fedora3DataInterface.java
+++ b/src/main/java/org/fcrepo/connector/fedora3/Fedora3DataInterface.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2013 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.connector.fedora3;
+
+/**
+ * An base class that encapsulates the logic to access content from a fedora 3
+ * repository.  This abstract class, while exposing the methods neccessary to
+ * implement a federation over fedora 3 content is agnostic about the way data
+ * is retrieved from said repository
+ * 
+ * @author Michael Durbin
+ */
+public interface Fedora3DataInterface {
+
+    /**
+     * Gets a FedoraObjectRecord that encapsulates a summary of the object with
+     * the given pid in the fedora 3 repository exposed through this interface.
+     */
+    public FedoraObjectRecord getObjectByPid(String pid);
+
+    /**
+     * Determines if an object with the given pid exists in the fedora 3
+     * repository exposed through this interface.
+     */
+    public boolean doesObjectExist(String pid);
+
+    /**
+     * Gets a page of object pids that exist in the repository.
+     */
+    public String[] getObjectPids(int offset, int pageSize);
+
+    /**
+     * Gets information about a given datastream for a given pid.
+     */
+    public FedoraDatastreamRecord getDatastream(String pid,
+            String dsid);
+
+    /**
+     * Determines if an object with the given pid exists and has a datastream
+     * with the given dsid.
+     */
+    public boolean doesDatastreamExist(String pid, String dsid);
+
+}

--- a/src/main/java/org/fcrepo/connector/fedora3/Fedora3FederationConnector.java
+++ b/src/main/java/org/fcrepo/connector/fedora3/Fedora3FederationConnector.java
@@ -1,0 +1,243 @@
+/**
+ * Copyright 2013 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.connector.fedora3;
+
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.jcr.NamespaceRegistry;
+import javax.jcr.RepositoryException;
+
+import org.fcrepo.connector.fedora3.rest.RESTFedora3DataImpl;
+import org.fcrepo.jcr.FedoraJcrTypes;
+import org.infinispan.schematic.document.Document;
+import org.modeshape.jcr.api.JcrConstants;
+import org.modeshape.jcr.api.nodetype.NodeTypeManager;
+import org.modeshape.jcr.federation.spi.DocumentWriter;
+import org.modeshape.jcr.federation.spi.PageKey;
+import org.modeshape.jcr.federation.spi.Pageable;
+import org.modeshape.jcr.federation.spi.ReadOnlyConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A ReadOnly connector to a fedora 3 repository.
+ * 
+ * @author Michael Durbin
+ */
+public class Fedora3FederationConnector extends ReadOnlyConnector
+         implements Pageable, FedoraJcrTypes {
+
+    private static final Logger LOGGER
+        = LoggerFactory.getLogger(Fedora3FederationConnector.class);
+
+    public static final String NT_F3_REPOSITORY = "fedora:repository";
+
+    protected Fedora3DataInterface f3;
+
+    /**
+     * Set by reflection, this is the URL for the fedora repository over which
+     * this connector federates.
+     */
+    protected String fedoraUrl;
+
+    /**
+     * Set by reflection, this is the username to access the fedora 3
+     * repository over which this connector federates.  This user should have
+     * access to all content that is meant to be exposed in the federation.
+     */
+
+    protected String username;
+
+    /**
+     * Set by reflection, this is the password to access the fedora 3
+     * repository over which this connector federates.
+     */
+    protected String password;
+
+    /**
+     * Set by reflection, this member variables controls the size of the pages
+     * requested from the fedora 3 instance when listing children.
+     */
+    protected int pageSize = 20;
+
+    /**
+     * {@inheritDoc}
+     */
+    public void initialize(NamespaceRegistry registry,
+            NodeTypeManager nodeTypeManager)
+        throws RepositoryException, IOException {
+        super.initialize(registry, nodeTypeManager);
+
+        LOGGER.trace("Initializing");
+        try {
+            if (fedoraUrl != null && username != null && password != null) {
+                f3 = new RESTFedora3DataImpl(fedoraUrl, username,
+                        password);
+            } else {
+                throw new RepositoryException("Requred parameters missing, "
+                        + "ensure that \"fedoraUrl\", \"username\" and "
+                        + " \"password\" are set!");
+            }
+        } catch (Throwable t) {
+            throw new RepositoryException("Error starting fedora connector!",
+                    t);
+        }
+        LOGGER.trace("Initialized");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Document getDocumentById(String idStr) {
+        LOGGER.trace("getDocumentById " + idStr);
+        ID id = new ID(idStr);
+        DocumentWriter writer = newDocument(idStr);
+        if (id.isRootID()) {
+            // return a root object
+            writer.setPrimaryType(JcrConstants.NT_FOLDER);
+            writer.addMixinType(NT_F3_REPOSITORY);
+            addRepositoryChildren(writer, idStr, 0, pageSize);
+            return writer.document();
+        } else if (id.isObjectID()) {
+            // return an object node
+            FedoraObjectRecord o = f3.getObjectByPid(id.getPid());
+            writer.setPrimaryType(JcrConstants.NT_FOLDER);
+            writer.setParent(ID.ROOT_ID.getId());
+            writer.addMixinType(FEDORA_OBJECT);
+            if (o.getModificationDate() != null) {
+                writer.addProperty(JCR_LASTMODIFIED,
+                        factories().getDateFactory().create(
+                                o.getModificationDate()));
+            }
+            if (o.getCreatedDate() != null) {
+                writer.addProperty(JCR_CREATED,
+                        factories().getDateFactory().create(
+                                o.getCreatedDate()));
+            }
+            addObjectChildren(writer, o);
+            return writer.document();
+        } else if (id.isDatastreamID()) {
+            // return a datastream node
+            writer.setPrimaryType(JcrConstants.NT_FILE);
+            writer.setParent(id.getParentId());
+            writer.addMixinType(FEDORA_DATASTREAM);
+            FedoraDatastreamRecord ds
+                = f3.getDatastream(id.getPid(), id.getDSID());
+            if (ds.getModificationDate() != null) {
+                writer.addProperty(JCR_LASTMODIFIED,
+                        factories().getDateFactory().create(
+                                ds.getModificationDate()));
+            }
+            if (ds.getModificationDate() != null) {
+                writer.addProperty(JCR_CREATED,
+                        factories().getDateFactory().create(
+                                ds.getCreatedDate()));
+            }
+            ID contentId = ID.contentID(id.getPid(), id.getDSID());
+            writer.addChild(contentId.getId(), contentId.getName());
+            return writer.document();
+        } else if (id.isContentID()) {
+            // return a content node
+            FedoraDatastreamRecord ds = f3.getDatastream(id.getPid(),
+                    id.getDSID());
+            writer.setPrimaryType(JcrConstants.NT_RESOURCE);
+            writer.addMixinType(FEDORA_BINARY);
+            writer.setParent(id.getParentId());
+            try {
+                writer.addProperty(JcrConstants.JCR_DATA, ds.getContent());
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+            writer.setNotQueryable();
+            writer.addProperty(JcrConstants.JCR_MIME_TYPE, ds.getMimeType());
+            return writer.document();
+        } else {
+            return null;
+        }
+    }
+
+    private void addRepositoryChildren(DocumentWriter writer, String idStr,
+            int offset, int pageSize) {
+        ID id = new ID(idStr);
+        String[] childPids = f3.getObjectPids(offset, pageSize + 1);
+        for (String childPid : childPids) {
+            ID childId = ID.objectID(childPid);
+            LOGGER.trace("Added child " + childId.getId());
+            writer.addChild(childId.getId(), childId.getName());
+        }
+        // FIXME
+        // this is commented out because the UI requests all objects,
+        // which for most fedora repositories is too big a set.
+        //if (childPids.length <= pageSize + 1) {
+        //    writer.addPage(id, offset + pageSize, pageSize,
+        //            PageWriter.UNKNOWN_TOTAL_SIZE);
+        //}
+    }
+
+    private void addObjectChildren(DocumentWriter writer,
+            FedoraObjectRecord object) {
+        for (String dsidStr : object.listDatastreamIds()) {
+            ID dsid = ID.datastreamID(object.getPid(), dsidStr);
+            writer.addChild(dsid.getId(), dsid.getName());
+        }
+    }
+
+    @Override
+    public String getDocumentId(String externalPath) {
+        LOGGER.info("getDocumentId " + externalPath);
+        return externalPath;
+    }
+
+    @Override
+    public Collection<String> getDocumentPathsById(String id) {
+        LOGGER.info("getDocumentPathsById " + id);
+        return Collections.singletonList(id);
+    }
+
+    /**
+     * Checks if a document with the given id exists.
+     * @param idStr a {@code non-null} string representing the identifier within
+     * the system whose existence is being queried in this federation.
+     */
+    public boolean hasDocument(String idStr) {
+        LOGGER.info("hasDocument " + idStr);
+        ID id = new ID(idStr);
+        return (id.isRootID()
+                || (id.isObjectID() && f3.doesObjectExist(id.getPid())
+                || ((id.isDatastreamID() || id.isContentID())
+                && f3.doesDatastreamExist(id.getPid(), id.getDSID()))));
+    }
+
+    @Override
+    public Document getChildren(PageKey pageKey) {
+        LOGGER.info("getChildren " + pageKey);
+        ID parentId = new ID(pageKey.getParentId());
+        if (parentId.isRootID()) {
+            DocumentWriter writer = newDocument(parentId.getId());
+            writer.setPrimaryType(NT_F3_REPOSITORY);
+            addRepositoryChildren(writer, parentId.getId(),
+                    pageKey.getOffsetInt(), (int) pageKey.getBlockSize());
+            return writer.document();
+        } else {
+            // get the datastreams
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/main/java/org/fcrepo/connector/fedora3/FedoraDatastreamRecord.java
+++ b/src/main/java/org/fcrepo/connector/fedora3/FedoraDatastreamRecord.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2013 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.connector.fedora3;
+
+import java.util.Date;
+
+import org.modeshape.jcr.value.BinaryValue;
+
+/**
+ * An interface to expose enough information about a Fedora 3 datastream to
+ * import it into fedora 4.
+ * 
+ * @author Michael Durbin
+ */
+public interface FedoraDatastreamRecord {
+
+    /**
+     * Gets the DSID.
+     */
+    public String getId();
+
+    /**
+     * Gets the MIME type.
+     */
+    public String getMimeType();
+
+    /**
+     * Gets the modification date for the datastream described by this record.
+     */
+    public Date getModificationDate();
+
+    /**
+     * Gets the creation date for the datastream described by this record.
+     */
+    public Date getCreatedDate();
+
+    /**
+     * Gets a JCR BinaryValue representing the content of the datastream.
+     */
+    public BinaryValue getContent() throws Exception;
+
+    // TODO: expose other properties
+}

--- a/src/main/java/org/fcrepo/connector/fedora3/FedoraObjectRecord.java
+++ b/src/main/java/org/fcrepo/connector/fedora3/FedoraObjectRecord.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2013 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.connector.fedora3;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * An interface that exposes information about an object in fedora 3.
+ * Implementations may vary about how they determine this information, but
+ * all methods are expected to be implemented such that they return meaningful
+ * values.
+ * 
+ * @author Michael Durbin
+ */
+public interface FedoraObjectRecord {
+
+    /**
+     * Gets the pid for the object described by this record.
+     */
+    public String getPid();
+
+    /**
+     * Gets the modification date for the object described by this record.
+     */
+    public Date getModificationDate();
+
+    /**
+     * Gets the creation date for the object described by this record.
+     */
+    public Date getCreatedDate();
+
+    /**
+     * Gets a list ids (fedora DSID) for the datastreams that exist on the
+     * object described by this record.
+     */
+    public List<String> listDatastreamIds();
+
+}

--- a/src/main/java/org/fcrepo/connector/fedora3/ID.java
+++ b/src/main/java/org/fcrepo/connector/fedora3/ID.java
@@ -1,0 +1,187 @@
+/**
+ * Copyright 2013 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.connector.fedora3;
+
+import org.modeshape.common.text.Jsr283Encoder;
+import org.modeshape.jcr.api.JcrConstants;
+
+/**
+ * Encapsualtes the logic associated with mapping ids within the
+ * {@link Fedora3FederationConnector} to the types of objects each represents.
+ * 
+ * Objects within the federation can fall into 4 types:
+ * <ul>
+ *   <li>root - the ID for the federation node itself</li>
+ *   <li>
+ *     object - the ID of a node representing an object in the fedora 3
+ *     repository that is being federated over
+ *   </li>
+ *   <li>
+ *     datastream - the ID of a node representing a datastream from an object
+ *     in the fedora 3 repository that is being federated over
+ *   </li>
+ *   <li>content - the ID of content from a datastream</li>
+ * </ul>
+ * <p>
+ *   The IDs are meant to be opaque and the implementation may change in later
+ *   versions of this class, but for reference, the current implementation
+ *   creates ids in the following pattern. /, /pid, /pid/dsid, /pid/dsid/content
+ * </p>
+ * 
+ * @author Michael Durbin
+ */
+public class ID {
+
+    private String id;
+
+    /**
+     * A constructor that accepts a known id.
+     */
+    public ID(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets a name for the node with this id.
+     */
+    public String getName() {
+        if (isRootID()) {
+            return "/";
+        } else if (isContentID()) {
+            return JcrConstants.JCR_CONTENT;
+        } else {
+            return id.substring(id.lastIndexOf('/') + 1);
+        }
+    }
+
+    /**
+     * Gets the ID within the federation.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Gets the id for the parent within the federation of the node with
+     * this id.
+     */
+    public String getParentId() {
+        if (isRootID()) {
+            return null;
+        } else if (isObjectID()) {
+            return ROOT_ID.id;
+        } else if (isDatastreamID()) {
+            return objectID(getPid()).id;
+        } else {
+            assert(isContentID());
+            return datastreamID(getPid(), getDSID()).id;
+        }
+    }
+
+    /**
+     * Determines if the id is the root id.
+     */
+    public boolean isRootID() {
+        return "/".equals(id);
+    }
+
+    /**
+     * Determines if the id is for a fedora 3 object.
+     */
+    public boolean isObjectID() {
+        return id.split("/").length == 1;
+    }
+
+    /**
+     * Gets the PID associated with this id.  For "object" IDs this will be the
+     * PID of the object, for "datastream" IDs this will be the pid to which
+     * the datastream belongs and for "content" IDs this will be the PID of the
+     * object that contains the datastream whose content node has the given id.
+     * @return the pid, if one can be determined from the id.  This should
+     * return a non-null value unless this id is the root id.
+     */
+    public String getPid() {
+        if (isRootID()) {
+            return null;
+        } else {
+            String[] path = id.split("/");
+            return new Jsr283Encoder().decode(path[0]);
+        }
+    }
+
+    /**
+     * Gets the DSID associated with this id or null if the object represented
+     * by the node with this id does not pertain to a datastream or its
+     * content.
+     */
+    public String getDSID() {
+        String[] path = id.split("/");
+        if (path.length < 2) {
+            return null;
+        } else {
+            return new Jsr283Encoder().decode(path[1]);
+        }
+    }
+
+    /**
+     * Determines if the id is for a fedora 3 datastream.
+     */
+    public boolean isDatastreamID() {
+        return id.split("/").length == 2;
+    }
+
+    /**
+     * Determines if the id is for a fedora 3 datastream content node.
+     */
+    public boolean isContentID() {
+        return id.split("/").length == 3;
+    }
+
+    /**
+     * The ID for the root of the federation.
+     */
+    public static final ID ROOT_ID = new ID("/");
+
+    /**
+     * Gets the ID for the node within the federation representing an object
+     * with the given pid.
+     */
+    public static ID objectID(String pid) {
+        return new ID(new Jsr283Encoder().encode(pid));
+    }
+
+    /**
+     * Gets the ID for the node within the federation representing a datastream
+     * with the given dsid on the object in the federation having the given
+     * pid.
+     */
+    public static ID datastreamID(String pid, String datastream) {
+        return new ID(new Jsr283Encoder().encode(pid) + "/"
+                + new Jsr283Encoder().encode(datastream));
+    }
+
+    /**
+     * Gets the ID for the node within the federation representing datastream
+     * content with the given dsid on the object in the federation having the
+     * given pid.
+     */
+    public static ID contentID(String pid, String datastream) {
+        return new ID(new Jsr283Encoder().encode(pid) + "/"
+                + new Jsr283Encoder().encode(datastream) + "/"
+                + JcrConstants.JCR_CONTENT);
+    }
+}

--- a/src/main/java/org/fcrepo/connector/fedora3/rest/DefaultFedoraObjectRecordImpl.java
+++ b/src/main/java/org/fcrepo/connector/fedora3/rest/DefaultFedoraObjectRecordImpl.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2013 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.connector.fedora3.rest;
+
+import java.util.Date;
+import java.util.List;
+
+import org.fcrepo.connector.fedora3.FedoraObjectRecord;
+
+/**
+ * A default implementation of the FedoraObjectRecord with package protected
+ * member variables that contain the results of the few required methods.
+ * 
+ * @author Michael Durbin
+ */
+public class DefaultFedoraObjectRecordImpl implements FedoraObjectRecord {
+
+    public String pid;
+
+    public Date lastModDate;
+
+    public Date createdDate;
+
+    public List<String> datastreams;
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getPid() {
+        return pid;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Date getModificationDate() {
+        return lastModDate;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Date getCreatedDate() {
+        return createdDate;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public List<String> listDatastreamIds() {
+        return datastreams;
+    }
+
+}

--- a/src/main/java/org/fcrepo/connector/fedora3/rest/RESTFedora3DataImpl.java
+++ b/src/main/java/org/fcrepo/connector/fedora3/rest/RESTFedora3DataImpl.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2013 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.connector.fedora3.rest;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.yourmediashelf.fedora.generated.access.FedoraRepository;
+import org.fcrepo.connector.fedora3.Fedora3DataInterface;
+import org.fcrepo.connector.fedora3.FedoraDatastreamRecord;
+import org.fcrepo.connector.fedora3.FedoraObjectRecord;
+import org.slf4j.Logger;
+
+import com.yourmediashelf.fedora.client.FedoraClient;
+import com.yourmediashelf.fedora.client.FedoraClientException;
+import com.yourmediashelf.fedora.client.FedoraCredentials;
+import com.yourmediashelf.fedora.generated.access.DatastreamType;
+import com.yourmediashelf.fedora.generated.access.ObjectProfile;
+
+/**
+ * An implementation of Fedora3DataInterface that uses the REST API to access
+ * fedora content.
+ * 
+ * @author Michael Durbin
+ */
+public class RESTFedora3DataImpl implements Fedora3DataInterface {
+
+    private static final Logger LOGGER
+        = getLogger(RESTFedora3DataImpl.class);
+
+    private FedoraClient fc;
+
+    /**
+     * Constructor with credentials necessary for a connection to fedora's REST
+     * API.
+     */
+    public RESTFedora3DataImpl(String fedoraUrl, String username,
+            String password) throws MalformedURLException,
+            FedoraClientException {
+        initialize(new FedoraClient(
+                new FedoraCredentials(fedoraUrl, username, password)));
+    }
+
+    private void initialize(FedoraClient fc) throws FedoraClientException {
+        this.fc = fc;
+        FedoraRepository r = FedoraClient.describeRepository().execute(fc)
+                .getRepositoryInfo();
+        LOGGER.debug("Initialized connection to fedora "
+                + r.getRepositoryVersion() + " at "
+                + r.getRepositoryBaseURL() + ".");
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public FedoraObjectRecord getObjectByPid(String pid) {
+        try {
+            DefaultFedoraObjectRecordImpl r
+                = new DefaultFedoraObjectRecordImpl();
+            r.pid = pid;
+            ObjectProfile op = FedoraClient.getObjectProfile(pid)
+                    .execute(fc).getObjectProfile();
+            r.createdDate = op.getObjCreateDate()
+                    .toGregorianCalendar().getTime();
+            r.lastModDate = op.getObjLastModDate()
+                    .toGregorianCalendar().getTime();
+            List<String> datastreams = new ArrayList<String>();
+            for (DatastreamType ds : FedoraClient.listDatastreams(pid)
+                    .execute(fc).getDatastreams()) {
+                datastreams.add(ds.getDsid());
+            }
+            r.datastreams = datastreams;
+            return r;
+        } catch (FedoraClientException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean doesObjectExist(String pid) {
+        try {
+            return FedoraClient.getObjectProfile(pid).execute(fc).getStatus()
+                    == 200;
+        } catch (FedoraClientException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String[] getObjectPids(int offset, int pageSize) {
+        try {
+            List<String> pids = FedoraClient.findObjects()
+                    .maxResults(pageSize).query("").pid().execute(fc).getPids();
+            String[] result = new String[pids.size()];
+            for (int i = 0; i < pids.size(); i ++) {
+                result[i] = pids.get(i);
+            }
+            LOGGER.info("At least " + pids.size() + " objects found");
+            return result;
+        } catch (FedoraClientException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public FedoraDatastreamRecord getDatastream(String pid, String dsid) {
+        try {
+            return new RESTFedoraDatastreamRecordImpl(fc, pid, dsid);
+        } catch (FedoraClientException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean doesDatastreamExist(String pid, String dsid) {
+        try {
+            return FedoraClient.getDatastream(pid, dsid).execute(fc)
+                    .getStatus() == 200;
+        } catch (FedoraClientException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+}

--- a/src/main/java/org/fcrepo/connector/fedora3/rest/RESTFedoraDatastreamRecordImpl.java
+++ b/src/main/java/org/fcrepo/connector/fedora3/rest/RESTFedoraDatastreamRecordImpl.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright 2013 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.connector.fedora3.rest;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.InputStream;
+import java.util.Date;
+
+import javax.jcr.RepositoryException;
+
+import org.fcrepo.connector.fedora3.FedoraDatastreamRecord;
+import org.fcrepo.connector.fedora3.ID;
+import org.modeshape.common.util.SecureHash;
+import org.modeshape.common.util.SecureHash.Algorithm;
+import org.modeshape.jcr.value.BinaryKey;
+import org.modeshape.jcr.value.BinaryValue;
+import org.modeshape.jcr.value.binary.ExternalBinaryValue;
+import org.slf4j.Logger;
+
+import com.yourmediashelf.fedora.client.FedoraClient;
+import com.yourmediashelf.fedora.client.FedoraClientException;
+import com.yourmediashelf.fedora.generated.management.DatastreamProfile;
+
+// TODO: add a date-time to ensure that the content is the same as
+// the date the hash was computed
+
+/**
+ * An implementation of {@link FedoraDatastreamRecord} that gets all of its
+ * information using the fedora 3 REST API.
+ * 
+ * @author Michael Durbin
+ */
+public class RESTFedoraDatastreamRecordImpl
+        implements FedoraDatastreamRecord {
+
+    private static final Logger LOGGER
+        = getLogger(RESTFedoraDatastreamRecordImpl.class);
+
+    private DatastreamProfile ds;
+
+    private FedoraClient fc;
+
+    private String pid;
+
+    private String dsid;
+
+    private byte[] sha1;
+
+    /**
+     * A constructor that takes as a parameter the DatastreamType object that
+     * was returned by the FedoraClient as its source for information about the
+     * fedora 3 datastream to be described by this object.
+     */
+    public RESTFedoraDatastreamRecordImpl(FedoraClient fc, String pid,
+            String dsId)
+        throws FedoraClientException {
+        this.fc = fc;
+        this.pid = pid;
+        this.dsid = dsId;
+        ds = FedoraClient.getDatastream(pid, dsId).execute(fc)
+                .getDatastreamProfile();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getId() {
+        return ds.getDsID();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getMimeType() {
+        return ds.getDsMIME();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Date getModificationDate() {
+        return ds.getDsCreateDate().toGregorianCalendar().getTime();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Date getCreatedDate() {
+        return ds.getDsCreateDate().toGregorianCalendar().getTime();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public BinaryValue getContent() throws Exception {
+        return new Fedora3DatastreamBinaryValue();
+    }
+
+    /**
+     * Gets a SHA1 hash of the content of the datastreams.  The current
+     * implementation checks first to see if fedora 3 provides this information
+     * and failing that, computes it.
+     * @throws FedoraClientException
+     */
+    public byte[] getSha1() throws Exception {
+        if (sha1 != null) {
+            return sha1;
+        }
+        if (ds.getDsChecksumType().equalsIgnoreCase("SHA-1")
+                && ds.getDsChecksum() != null) {
+            sha1 = getSha1BytesFromHexString(ds.getDsChecksum());
+            LOGGER.trace("Loaded SHA1 for " + pid + " " + dsid
+                    + " from repository.");
+            return sha1;
+        } else {
+            long start = System.currentTimeMillis();
+            InputStream is = FedoraClient.getDatastreamDissemination(pid, dsid)
+                    .execute(fc).getEntityInputStream();
+            try {
+                sha1 = SecureHash.getHash(Algorithm.SHA_1, is);
+                return sha1;
+            } finally {
+                is.close();
+                LOGGER.trace("Computed SHA-1 from " + dsid + " on " + pid
+                        + " in " + (System.currentTimeMillis() - start)
+                        + "ms.");
+            }
+        }
+    }
+
+    /**
+     * Converts a String of hexidecimal digits (0-F) into the bytes that would
+     * be expressed by such a String.
+     */
+    protected static byte[] getSha1BytesFromHexString(String hexStr) {
+        int len = hexStr.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2]
+                = (byte) ((Character.digit(hexStr.charAt(i), 16) << 4)
+                + Character.digit(hexStr.charAt(i + 1), 16));
+        }
+        return data;
+    }
+
+    public class Fedora3DatastreamBinaryValue extends ExternalBinaryValue {
+
+        private FedoraClient fc;
+
+        private Fedora3DatastreamBinaryValue() throws Exception {
+            super(new BinaryKey(getSha1()), ds.getDsID(), ID.contentID(pid,
+                    dsid).getId(), ds.getDsSize().longValue(), null, null);
+        }
+
+        /**
+         * Gets the InputStream for the content.
+         */
+        public InputStream getStream() throws RepositoryException {
+            try {
+                return FedoraClient.getDatastreamDissemination(pid, dsid)
+                        .execute(fc).getEntityInputStream();
+            } catch (FedoraClientException e) {
+                throw new RepositoryException(e);
+            }
+        }
+
+    }
+
+}

--- a/src/test/java/org/fcrepo/connector/fedora3/Fedora3FederationConnectorTest.java
+++ b/src/test/java/org/fcrepo/connector/fedora3/Fedora3FederationConnectorTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2013 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.connector.fedora3;
+
+import static org.mockito.Mockito.*;
+
+import org.fcrepo.connector.fedora3.rest.DefaultFedoraObjectRecordImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.modeshape.jcr.federation.spi.DocumentWriter;
+import org.infinispan.schematic.document.EditableDocument;
+import org.modeshape.jcr.federation.spi.PageKey;
+import org.modeshape.jcr.value.ValueFactories;
+
+import javax.jcr.RepositoryException;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ * @author Michael Durbin
+ */
+public class Fedora3FederationConnectorTest {
+
+    @Mock Fedora3DataInterface mockF3;
+
+    @Mock FedoraDatastreamRecord mockDCDatastream;
+
+    @Mock EditableDocument mockument;
+
+    @Mock DocumentWriter mockumentWriter;
+
+    Fedora3FederationConnector c;
+
+    /**
+     * Sets up a Fedora3DataInterface that pretends to be a fedora repository
+     * that contains two objects, "changeme:1" and "changeme:2".  The object
+     * "changeme:2" has two datastreams: "DC" and "RELS-EXT".
+     */
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        when(mockF3.getObjectPids(anyInt(), anyInt())).thenReturn(new String[] { "changeme:1", "changeme:2" });
+        DefaultFedoraObjectRecordImpl changeme1 = new DefaultFedoraObjectRecordImpl();
+        changeme1.pid = "changeme:1";
+        when(mockF3.getObjectByPid("changeme:1")).thenReturn(changeme1);
+        changeme1.datastreams = new ArrayList<String>();
+        DefaultFedoraObjectRecordImpl changeme2 = new DefaultFedoraObjectRecordImpl();
+        changeme2.pid = "changeme:2";
+        changeme2.datastreams = Arrays.asList(new String[] { "DC", "RELS-EXT"});
+        when(mockF3.getObjectByPid("changeme:2")).thenReturn(changeme2);
+        when(mockF3.getDatastream("changeme:2", "DC")).thenReturn(mockDCDatastream);
+        when(mockF3.doesObjectExist("changeme:1")).thenReturn(true);
+        when(mockF3.doesObjectExist("changeme:2")).thenReturn(true);
+        when(mockF3.doesDatastreamExist("changeme:2", "DC")).thenReturn(true);
+        when(mockF3.doesDatastreamExist("changeme:2", "RELS-EXT")).thenReturn(true);
+
+        c = new MockedFedora3FederationConnector();
+        c.f3 = mockF3;
+    }
+
+    @Test
+    public void testInitialization() throws Exception {
+        try {
+            new Fedora3FederationConnector().initialize(null, null);
+            Assert.fail("Initialization should fail without having set required properties.");
+        } catch (RepositoryException e) {
+        }
+
+        Fedora3FederationConnector c = new Fedora3FederationConnector();
+        c.fedoraUrl = "malformed-url";
+        c.username = "username";
+        c.password = "password";
+        try {
+            c.initialize(null, null);
+        } catch (RepositoryException e) {
+            Assert.assertEquals("Initialization should fail because of bad URL.", e.getCause().getClass(), java.net.MalformedURLException.class);
+        }
+    }
+
+    @Test
+    public void testGetDocumentById() throws Exception {
+        Assert.assertNotNull("The root object is exposed by the federation.", c.getDocumentById(ID.ROOT_ID.getId()));
+        Assert.assertNotNull("The object \"changeme:1\" is exposed by the federation.", c.getDocumentById(ID.objectID("changeme:1").getId()));
+        Assert.assertNotNull("The object \"changeme:2\" is exposed by the federation.", c.getDocumentById(ID.objectID("changeme:2").getId()));
+        Assert.assertNotNull("The datastream \"DC\" on \"changeme:2\" exists.", c.getDocumentById(ID.datastreamID("changeme:2", "DC").getId()));
+        Assert.assertNotNull("The content of datastream \"DC\" on \"changeme:2\" exists.", c.getDocumentById(ID.contentID("changeme:2", "DC").getId()));
+
+    }
+
+    @Test
+    public void testHasDocument() {
+        Assert.assertTrue("Root document should exist.", c.hasDocument(ID.ROOT_ID.getId()));
+        Assert.assertTrue("Document for \"changeme:1\" should exist.", c.hasDocument(ID.objectID("changeme:1").getId()));
+        Assert.assertTrue("Document for \"DC\" datastream on \"changeme:2\" should exist.", c.hasDocument(ID.datastreamID("changeme:2", "DC").getId()));
+        Assert.assertTrue("Document for content of \"DC\" datastream on \"changeme:2\" should exist.", c.hasDocument(ID.contentID("changeme:2", "DC").getId()));
+    }
+
+    @Test
+    public void testGetChildren() {
+        c.getChildren(new PageKey(ID.ROOT_ID.getId(), "0", 100));
+    }
+
+    /**
+     * Overrides certain methods to allow for unit testing.
+     */
+    private class MockedFedora3FederationConnector extends Fedora3FederationConnector {
+
+        /**
+         * Overrides the implementation in org.modeshape.jcr.federation.spi.Connector to
+         * return a dummy implementation.
+         */
+        public DocumentWriter newDocument(String id) {
+            when(mockumentWriter.document()).thenReturn(mockument);
+            return mockumentWriter;
+        }
+    }
+}

--- a/src/test/java/org/fcrepo/connector/fedora3/IDTest.java
+++ b/src/test/java/org/fcrepo/connector/fedora3/IDTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2013 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.connector.fedora3;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.modeshape.jcr.api.JcrConstants;
+
+/**
+ * @author Michael Durbin
+ */
+public class IDTest {
+
+    @Test
+    public void testRootId() {
+        Assert.assertTrue("The static root id should be the root id.",
+                ID.ROOT_ID.isRootID());
+        Assert.assertFalse("The root id should not be an object id.",
+                ID.ROOT_ID.isObjectID());
+        Assert.assertFalse("The root id should not be a datastream id.",
+                ID.ROOT_ID.isDatastreamID());
+        Assert.assertTrue("The root id should be \"/\".", ID.ROOT_ID.getId().equals("/"));
+        Assert.assertTrue("The item with id \"/\" should be root.", new ID("/").isRootID());
+        Assert.assertNull("The root id should have no parent.", ID.ROOT_ID.getParentId());
+        Assert.assertTrue("The root name should have at least one character.", ID.ROOT_ID.getName().length() >= 1);
+        Assert.assertNull("The root id should not be associated with any pid.", ID.ROOT_ID.getPid());
+    }
+
+    @Test
+    public void testObjectId() {
+        String pid = "changeme:1";
+        ID id = ID.objectID(pid);
+        Assert.assertTrue("The object ID should  be an object id.",
+                id.isObjectID());
+        Assert.assertFalse("The object ID should not be a root id.",
+                id.isRootID());
+        Assert.assertFalse("The object ID should not be a datastream id.",
+                id.isDatastreamID());
+        Assert.assertTrue("The object ID should retain the pid.",
+                id.getPid().equals(pid));
+        Assert.assertTrue("The object ID be the parent of the root id.",
+                id.getParentId().equals(ID.ROOT_ID.getId()));
+        Assert.assertNull("The object ID should not contain a dsid.",
+                id.getDSID());
+    }
+
+    @Test
+    public void testDatastreamId() {
+        String pid = "changeme:1";
+        String dsId = "RELS-EXT";
+        ID objectId = ID.objectID(pid);
+        ID id = ID.datastreamID(pid, dsId);
+        Assert.assertTrue("The datastream ID should  be a datastream id.",
+                id.isDatastreamID());
+        Assert.assertFalse("The datastream ID should not be a root id.",
+                id.isRootID());
+        Assert.assertFalse("The datastream ID should not be an object id.",
+                id.isObjectID());
+        Assert.assertTrue("The datastream ID should retain the pid.",
+                id.getPid().equals(pid));
+        Assert.assertEquals("The datastream ID be the parent of an object id.",
+                id.getParentId(), objectId.getId());
+        Assert.assertEquals("The datastream ID should contain a dsid.",
+                id.getDSID(), dsId);
+    }
+
+    @Test
+    public void testContentId() {
+        String pid = "changeme:1";
+        String dsId = "RELS-EXT";
+        ID id = ID.contentID(pid, dsId);
+        ID datastreamId = ID.datastreamID(pid, dsId);
+        Assert.assertTrue("The content ID should  be a content id.",
+                id.isContentID());
+        Assert.assertFalse("The content ID should not be a root id.",
+                id.isRootID());
+        Assert.assertFalse("The content ID should not be an object id.",
+                id.isObjectID());
+        Assert.assertFalse("The content ID should not be a datastream id",
+                id.isDatastreamID());
+        Assert.assertTrue("The content ID should retain the pid.",
+                id.getPid().equals(pid));
+        Assert.assertEquals("The content ID be the child of a datastream id.",
+                id.getParentId(), datastreamId.getId());
+        Assert.assertEquals("The content ID should contain a dsid.",
+                id.getDSID(), dsId);
+        Assert.assertEquals("The content ID should be the JCR constant.", id.getName(), JcrConstants.JCR_CONTENT);
+    }
+
+        /**
+         * The pattern for names vs ids is such that an item's id is that
+         * item's parent's id followed by a '/' and then the items name.
+         */
+        @Test
+        public void testNamePattern() {
+            ID contentId = ID.contentID("changeme:1", "RELS-EXT");
+            Assert.assertEquals("An item's id should be the concatenation of its parent's id, a slash and it's name.", contentId.getId(), contentId.getParentId() + "/" + contentId.getName());
+            ID dsId = new ID(contentId.getParentId());
+            Assert.assertEquals("An item's id should be the concatenation of its parent's id, a slash and it's name.", dsId.getId(), dsId.getParentId() + "/" + dsId.getName());
+        }
+}

--- a/src/test/java/org/fcrepo/connector/fedora3/rest/RESTFedora3DataImplTest.java
+++ b/src/test/java/org/fcrepo/connector/fedora3/rest/RESTFedora3DataImplTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2013 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.connector.fedora3.rest;
+
+/**
+ * Because the RESTFedoraDataImpl class is a quick and dirty implementation
+ * that does nothing but wrap fedora 3 REST API calls, there are no unit
+ * tests at this time.  Future integration tests will cover the code.
+ *
+ * @author Michael Durbin
+ */
+public class RESTFedora3DataImplTest {
+}

--- a/src/test/java/org/fcrepo/connector/fedora3/rest/RESTFedoraDatastreamRecordImplTest.java
+++ b/src/test/java/org/fcrepo/connector/fedora3/rest/RESTFedoraDatastreamRecordImplTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2013 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.connector.fedora3.rest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Random;
+
+/**
+ * Because the RESTFedoraDatastreamRecordImpl class is a quick and dirty
+ * implementation that is intended to be a proof of concept, and because
+ * future integration tests will fully cover the code, these unit tests
+ * only cover the small amount of code that represents logic that could
+ * be reused.
+ *
+ * @author Michael Durbin
+ */
+public class RESTFedoraDatastreamRecordImplTest {
+
+    @Test
+    public void testGetSha1() {
+        byte[] bytes = new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF };
+        String string = "0123456789ABCDEF";
+        Assert.assertTrue(Arrays.equals(RESTFedoraDatastreamRecordImpl.getSha1BytesFromHexString(string), bytes));
+    }
+}


### PR DESCRIPTION
This should address tracker ticket 55769132 as well as comments from the previous pull request.

Test coverage over the *.rest package is known to be sparse as that the "proof-of-concept" part and is basically just a thin wrapper over the FedoraClient code.  Furthermore, that will be tested by forthcoming integration tests that are part of another ticket.
