### PR TITLE
Added integration test rigging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,26 @@ fedora 3 conent in a fedora 4 repository.
 ## Fetching the source code
 
 ```bash
-$ git clone https://github.com/mikedurbin/fcrepo-fedora3-federation-connector
+$ git clone https://github.com/futures/fcrepo-fedora3-federation-connector
 ```
 ### Update build configuration to include new module
 
-In fcrepo4/fcrepo4-webapp/pom.xml add
+The following steps reference a fcrepo4 source tree.  You can fetch this
+from https://github.com/futures/fcrepo4.
+
+In fcrepo4/fcrepo-webapp/pom.xml add
 
 	<dependency>
 	  <groupId>org.fcrepo</groupId>
 	  <artifactId>fcrepo-fedora3-federation-connector</artifactId>
 	  <version>${project.version}</version>
+	    <exclusions>
+	      <exclusion>
+	        <groupId>com.hp.hpl.jena</groupId>
+	        <artifactId>jena</artifactId>
+	      </exclusion>
+	    </exclusions>
+	  </dependency>
 	</dependency>
 
 In fcrepo4/fcrepo-kernel/src/main/resources/fedora-node-types.cnd add
@@ -42,7 +52,8 @@ In fcrepo4/fcrepo-kernel/src/main/resources/fedora-node-types.cnd add
 	 */
 	[fedora:repository]
 
-In fcrepo4/fcrepo-jcr/src/main/resources/config/single/repository.json (or whichever you're using) add
+In the json file referenced in fcrepo4/fcrepo-webapp/src/main/resources/spring/repo.xml, 
+(which at the time of this writing is fcrepo4/fcrepo-jcr/src/main/resources/config/rest-sessions/repository.json add
 
 	"externalSources" : {
 	  "fedora3" : {
@@ -59,7 +70,7 @@ Note: pageSize is optional and represents the size of pages of objects that are 
 repository node.
 
 ### Compile and install the code
-For each of the components modified above, as well as this project:
+For this project, then each of the components modified above:
 
 ```bash
 $ mvn clean install

--- a/fcrepo-fedora3-federation-connector/pom.xml
+++ b/fcrepo-fedora3-federation-connector/pom.xml
@@ -19,7 +19,7 @@
     <foxml.dir>${project.build.directory}/foxml</foxml.dir>
     <datastreams.dir>${project.build.directory}/datastreams</datastreams.dir>
   </properties>
-  <packaging>war</packaging>
+  <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
@@ -32,12 +32,12 @@
       <artifactId>local-legacy-fedora3</artifactId>
       <version>${fedora3.version}</version>
       <type>war</type>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.yourmediashelf.fedora.client</groupId>
       <artifactId>fedora-client-core</artifactId>
       <version>0.7</version>
-      <classifier>with-dependencies</classifier>
       <exclusions>
         <exclusion>
           <groupId>xerces</groupId>
@@ -66,6 +66,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -90,11 +91,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.fcrepo</groupId>
-      <artifactId>fcrepo-fedora3-federation-connector</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>


### PR DESCRIPTION
Addresses tracker issue: 56135376

The mechanism for spinning up fedora 3 in cargo was copied from Adam Soroka's example.  The vast majority of this commit is a fedora-home directory that appears in the src/test/resources/fedora-home directory which can be ignored.

The basic operation now is that:
1.  A fedora 3 war file is built
2.  Before integration tests that war file is loaded in cargo on port 8081 (which is scattered throughout several configuration files)
3.  The single sample integration test brings up a fedora 4 instance that includes configurations (packaged here) so that it federates over the fedora 3 repository.  You can see in the logs where it connects to fedora 3, and indeed lists the default objects.
